### PR TITLE
bitfield: Added x86 model field decoding

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -14,11 +14,8 @@ cpuids:
           bounds:
             start: 0
             end: 4
-        - type: Int
+        - type: X86Model
           name: model
-          bounds:
-            start: 4
-            end: 8
         - type: Int
           name: family
           bounds:


### PR DESCRIPTION
This involves checking a number of places in the register to properly decode. Since this area is still prodominatly a bitfield and only will ever need one cpuid register to decode, It was just added as a special field.