### PR TITLE
bitfield: Added x86 family field decoding

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -16,7 +16,7 @@ cpuids:
             end: 4
         - type: X86Model
           name: model
-        - type: Int
+        - type: X86Family
           name: family
           bounds:
             start: 8


### PR DESCRIPTION
This is 2 seperate regions of a register making a seperate struct the better way to decode it properly