### PR TITLE
cpuid: limit search to current values

### DIFF
--- a/src/kvm.rs
+++ b/src/kvm.rs
@@ -18,33 +18,24 @@ impl KvmInfo {
 }
 
 impl CpuidDB for KvmInfo {
-    fn get_cpuid(&self, leaf: u32, subleaf: u32) -> CpuidResult {
-        self.cpuid_info
-            .as_slice()
-            .iter()
-            .find_map(|entry| {
-                if entry.function == leaf {
-                    if (subleaf == 0 && (entry.flags & KVM_CPUID_FLAG_SIGNIFCANT_INDEX) == 0)
-                        || (subleaf == entry.index)
-                    {
-                        Some(CpuidResult {
-                            eax: entry.eax,
-                            ebx: entry.ebx,
-                            ecx: entry.ecx,
-                            edx: entry.edx,
-                        })
-                    } else {
-                        None
-                    }
+    fn get_cpuid(&self, leaf: u32, subleaf: u32) -> Option<CpuidResult> {
+        self.cpuid_info.as_slice().iter().find_map(|entry| {
+            if entry.function == leaf {
+                if (subleaf == 0 && (entry.flags & KVM_CPUID_FLAG_SIGNIFCANT_INDEX) == 0)
+                    || (subleaf == entry.index)
+                {
+                    Some(CpuidResult {
+                        eax: entry.eax,
+                        ebx: entry.ebx,
+                        ecx: entry.ecx,
+                        edx: entry.edx,
+                    })
                 } else {
                     None
                 }
-            })
-            .unwrap_or(CpuidResult {
-                eax: 0,
-                ebx: 0,
-                ecx: 0,
-                edx: 0,
-            })
+            } else {
+                None
+            }
+        })
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,7 +3,7 @@
 use super::facts::{self, GenericFact};
 use super::{
     bitfield::{self, Facter},
-    is_empty_leaf, CpuidDB,
+    CpuidDB,
 };
 use core::arch::x86_64::CpuidResult;
 use enum_dispatch::enum_dispatch;
@@ -54,7 +54,11 @@ impl DisplayLeaf for StartLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        vec![cpuid.get_cpuid(leaf, 0)]
+        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
+            vec![cpuid]
+        } else {
+            vec![]
+        }
     }
     fn display_leaf(
         &self,
@@ -114,8 +118,7 @@ impl DisplayLeaf for StringLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        let cpuid = cpuid.get_cpuid(leaf, 0);
-        if !is_empty_leaf(&cpuid) {
+        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
             vec![cpuid]
         } else {
             vec![]
@@ -173,8 +176,7 @@ impl DisplayLeaf for BitFieldLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        let cpuid = cpuid.get_cpuid(leaf, 0);
-        if !is_empty_leaf(&cpuid) {
+        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
             vec![cpuid]
         } else {
             vec![]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -54,10 +54,9 @@ impl DisplayLeaf for StartLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
-            vec![cpuid]
-        } else {
-            vec![]
+        match cpuid.get_cpuid(leaf, 0) {
+            Some(cpuid) => vec![cpuid],
+            None => vec![],
         }
     }
     fn display_leaf(
@@ -118,10 +117,9 @@ impl DisplayLeaf for StringLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
-            vec![cpuid]
-        } else {
-            vec![]
+        match cpuid.get_cpuid(leaf, 0) {
+            Some(cpuid) => vec![cpuid],
+            None => vec![],
         }
     }
     fn display_leaf(
@@ -176,10 +174,9 @@ impl DisplayLeaf for BitFieldLeaf {
         leaf: u32,
         cpuid: &CPUIDFunc,
     ) -> Vec<CpuidResult> {
-        if let Some(cpuid) = cpuid.get_cpuid(leaf, 0) {
-            vec![cpuid]
-        } else {
-            vec![]
+        match cpuid.get_cpuid(leaf, 0) {
+            Some(cpuid) => vec![cpuid],
+            None => vec![],
         }
     }
     fn display_leaf(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use cpuinfo::msr::MSRValue;
 use cpuinfo::*;
 use enum_dispatch::enum_dispatch;
 use msr::MSRDesc;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::error::Error;
@@ -166,7 +166,7 @@ impl Command for Facts {
     }
 }
 
-fn read_facts_from_file<T: DeserializeOwned>(fname: &str) -> Result<Vec<YAMLFact>, Box<dyn Error>> {
+fn read_facts_from_file(fname: &str) -> Result<Vec<YAMLFact>, Box<dyn Error>> {
     let file = std::fs::File::open(fname)?;
     Ok(serde_yaml::from_reader(file)?)
 }
@@ -214,9 +214,8 @@ struct Diff {
 
 impl Command for Diff {
     fn run(&self, _config: &Definition) -> Result<(), Box<dyn Error>> {
-        let from: YAMLFactSet =
-            read_facts_from_file::<serde_yaml::Value>(&self.from_file_name)?.into();
-        let to: YAMLFactSet = read_facts_from_file::<serde_yaml::Value>(&self.to_file_name)?.into();
+        let from: YAMLFactSet = read_facts_from_file(&self.from_file_name)?.into();
+        let to: YAMLFactSet = read_facts_from_file(&self.to_file_name)?.into();
 
         let output = DiffOutput {
             added: from.added_facts(&to).map(Clone::clone).collect(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,9 @@ impl Command for Disp {
             display_raw()
         } else {
             println!("CPUID:");
+            let cpuid_db = cpuinfo::RunningCpuidDB::new();
             for (leaf, desc) in &config.cpuids {
-                if let Some(bound) = desc.bind_leaf(*leaf, &cpuid) {
+                if let Some(bound) = desc.bind_leaf(*leaf, &cpuid_db) {
                     println!("{:#010x}: {}", leaf, bound);
                 }
             }


### PR DESCRIPTION
Improved the APIs to make it clearer when leafs are not present. There are a few ways to identify when to stop scanning mentioned in the manual. For displaying facts, the code will now not only use a zero check in some cases, It will also pay attention to the advertized limits from the CPU.