### PR TITLE
config: Corrected and enumerated more arch capabilities

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -129,15 +129,15 @@ msrs:
   - name: Arch Capabilities
     address: 0x10a
     fields:
-      - {type: Flag, name: "Rogue Data Cache Load", bit: 0}
-      - {type: Flag, name: "Enhanced IBRS", bit: 1}
-      - type: Flag
-        name: MDS_NO
-        bit: 5
-      - type: Flag
-        name: TAA_NO
-        bit: 8
-      - {type: Flag, name: "TSX_CTRL", bit: 7}
+      - {type: Flag, name: RDCL_NO, bit: 0}
+      - {type: Flag, name: IBRS_ALL, bit: 1}
+      - {type: Flag, name: RSBA, bit: 2}
+      - {type: Flag, name: SKIP_L1DF_VMENTRY, bit: 3}
+      - {type: Flag, name: SSB_NO, bit: 4}
+      - {type: Flag, name: MDS_NO, bit: 5}
+      - {type: Flag, name: IF_PSCHANGE_MC_NO, bit: 6}
+      - {type: Flag, name: TSX_CTRL, bit: 7}
+      - {type: Flag, name: TAA_NO, bit: 8}
   - name: Basic VMX
     address: 0x480
     fields:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -138,6 +138,13 @@ msrs:
       - {type: Flag, name: IF_PSCHANGE_MC_NO, bit: 6}
       - {type: Flag, name: TSX_CTRL, bit: 7}
       - {type: Flag, name: TAA_NO, bit: 8}
+      - {type: Flag, name: GDS_CTRL, bit: 25}
+      - {type: Flag, name: GDS_NO, bit: 26}
+  - name: Microcode Update Option Control
+    address: 0x123
+    fields:
+      - {type: Flag, name: "GDS_MITG_DIS", bit: 4}
+      - {type: Flag, name: "GDS_MITG_LOCK", bit: 5}
   - name: Basic VMX
     address: 0x480
     fields:


### PR DESCRIPTION
These are used to inform the OS about x86 branch prediction side channels.