### PR TITLE
CpuidIterator: Better identifies the last sub-leaf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,14 +186,9 @@ impl CpuidIterator {
 }
 
 fn is_empty_leaf(result: &CpuidResult) -> bool {
-    let CpuidResult {
-        eax,
-        ebx,
-        ecx,
-        edx: _,
-    } = result;
+    let CpuidResult { eax, ebx, ecx, edx } = result;
     // See
-    *eax == 0 && *ebx == 0 && *ecx & 0x0000FF00 == 0
+    *eax == 0 && *ebx == 0 && ((*ecx == 0 && *edx == 0) || (*ecx != 0 && *ecx & 0xFFFFFF00 == 0))
 }
 
 impl Iterator for CpuidIterator {


### PR DESCRIPTION
There is no one definition of what is the last sub-leaf. It must be determined by looking at what each leaf definition is. This may become more complicated as more are added.